### PR TITLE
Syntax typo

### DIFF
--- a/lab4-alu/README.md
+++ b/lab4-alu/README.md
@@ -118,7 +118,7 @@ An **opcode** (short for operation code) is a part of a machine language instruc
 
 
                when others =>
-                   sig_res <= b"0_0000";  -- Default case
+                   sig_res <= "0_0000";  -- Default case
            end case;
        end process p_alu;
 


### PR DESCRIPTION
Quote from VHDL reference guide @ https://peterfab.com/ref/vhdl/vdlande/literals.html

Bit vector literals may be expressed in binary (the default), opctal or hex. They may also contain embedded underscores for clarity. **these forms may not be used as std_logic_vector literals:**

BIT_8_BUS <= B"1111_1111";
BIT_9_BUS <= O"353";
BIT_16_BUS <= X"AA55";

If you add a B before the literal for a std_logic_vector, it will cause a compilation error because that notation is only valid for bit_vector types. Didn't test this.

*256448*